### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,7 @@ def serve_frontend(path="index.html"):
         return send_from_directory(app.static_folder, "index.html")
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.getenv("FLASK_DEBUG", "False").lower() in ["true", "1", "t"]
+    app.run(debug=debug_mode)
     
     gunicorn_app = app


### PR DESCRIPTION
Potential fix for [https://github.com/shyampillai07/WAF_Project/security/code-scanning/1](https://github.com/shyampillai07/WAF_Project/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using environment variables to control the debug mode. This way, we can set the debug mode to `True` only in a development environment and `False` in a production environment.

1. Modify the `app.run()` call to use an environment variable to determine the debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.
3. Ensure that the environment variable is set appropriately in the deployment environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
